### PR TITLE
Redirect root URL to GitHub repository

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,12 @@ const app = express()
 app.use(cors())
 app.use(moesifMiddleware())
 app.get('/favicon.ico', (req, res) => res.sendStatus(204))
+
+// Redirect the root URL to the github repository
+app.get('/', (req, res) => {
+  res.redirect('https://github.com/lukePeavey/quotable')
+})
+
 app.use(routes)
 app.use(handle404)
 app.use(logErrors)


### PR DESCRIPTION
The website for this project is still under construction. So right now the root URL (https://api.quotable.io/) simply responds with a `404` error (see #10).

Instead, have the root URL redirect to the github repository until website is complete