### PR TITLE
Feature: filter quotes by length

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Returns a single random quote from the database
 | param    | type     | Description                                                  |
 | :------- | :------- | :----------------------------------------------------------- |
 | tags     | `String` | Filter random quote by tag(s). Takes a list of one or more tag names, separated by a comma (meaning `AND`) or a pipe (meaning `OR`). A comma separated list will match quotes that have **_all_** of the given tags. While a pipe (`\|`) separated list will match quotes that have **_either_** of the provided tags. |
-| maxlength  | `Int` | The maximum Length in characters ( can be combined with `minlength` ) |
-| minlength | `Int`| The minimum Length in characters ( can be combined with `maxlength` )
+| maxLength  | `Int` | The maximum Length in characters ( can be combined with `minLength` ) |
+| minLength | `Int`| The minimum Length in characters ( can be combined with `maxLength` )
 
 #### Request
 
@@ -59,8 +59,8 @@ Get a paginated list of all quotations in the database. This method supports sev
 | limit    | `Int`    | The number of quotes to return per request. (for pagination).|
 | skip     | `Int`    | The number of items to skip (for pagination).                |
 | tags     | `String` | Filter quotes by tag(s). Takes a list of one or more tag names, separated by a comma (meaning `AND`) or a pipe (meaning `OR`). A comma separated list will match quotes that have **_all_** of the given tags. While a pipe (`\|`) separated list will match quotes that have **_either_** of the provided tags. |
-| maxlength  | `Int` | The maximum Length in characters ( can be combined with `minLength` ) |
-| minlength | `Int`| The minimum Length in characters ( can be combined with `maxLength` )
+| maxLength  | `Int` | The maximum Length in characters ( can be combined with `minLength` ) |
+| minLength | `Int`| The minimum Length in characters ( can be combined with `maxLength` )
 
 #### Request
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Returns a single random quote from the database
 | param    | type     | Description                                                  |
 | :------- | :------- | :----------------------------------------------------------- |
 | tags     | `String` | Filter random quote by tag(s). Takes a list of one or more tag names, separated by a comma (meaning `AND`) or a pipe (meaning `OR`). A comma separated list will match quotes that have **_all_** of the given tags. While a pipe (`\|`) separated list will match quotes that have **_either_** of the provided tags. |
-
+| maxlength  | `Int` | The maximum Length in characters ( can be combined with `minlength` ) |
+| minlength | `Int`| The minimum Length in characters ( can be combined with `maxlength` )
 
 #### Request
 
@@ -40,7 +41,8 @@ https://api.quotable.io/random
   _id: string,
   content: string,
   author: string,
-  tags: [string]
+  tags: [string],
+  length: number
 }
 ```
 
@@ -57,6 +59,8 @@ Get a paginated list of all quotations in the database. This method supports sev
 | limit    | `Int`    | The number of quotes to return per request. (for pagination).|
 | skip     | `Int`    | The number of items to skip (for pagination).                |
 | tags     | `String` | Filter quotes by tag(s). Takes a list of one or more tag names, separated by a comma (meaning `AND`) or a pipe (meaning `OR`). A comma separated list will match quotes that have **_all_** of the given tags. While a pipe (`\|`) separated list will match quotes that have **_either_** of the provided tags. |
+| maxlength  | `Int` | The maximum Length in characters ( can be combined with `minlength` ) |
+| minlength | `Int`| The minimum Length in characters ( can be combined with `maxlength` )
 
 #### Request
 
@@ -77,7 +81,7 @@ https://api.quotable.io/quotes
   // "page" of results.
   lastItemIndex: number
   // The array of quotes
-  results: {_id: string, content: string, author: string, tags: [string]}[]
+  results: {_id: string, content: string, author: string, tags: [string], length: number}[]
 }
 ```
 
@@ -98,7 +102,8 @@ https://api.quotable.io/quotes/:id
   _id: string,
   content: string,
   author: string,
-  tags: [string]
+  tags: [string],
+  length: number
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Get a paginated list of all quotations in the database. This method supports sev
 | limit    | `Int`    | The number of quotes to return per request. (for pagination).|
 | skip     | `Int`    | The number of items to skip (for pagination).                |
 | tags     | `String` | Filter quotes by tag(s). Takes a list of one or more tag names, separated by a comma (meaning `AND`) or a pipe (meaning `OR`). A comma separated list will match quotes that have **_all_** of the given tags. While a pipe (`\|`) separated list will match quotes that have **_either_** of the provided tags. |
-| maxlength  | `Int` | The maximum Length in characters ( can be combined with `minlength` ) |
-| minlength | `Int`| The minimum Length in characters ( can be combined with `maxlength` )
+| maxlength  | `Int` | The maximum Length in characters ( can be combined with `minLength` ) |
+| minlength | `Int`| The minimum Length in characters ( can be combined with `maxLength` )
 
 #### Request
 
@@ -81,7 +81,7 @@ https://api.quotable.io/quotes
   // "page" of results.
   lastItemIndex: number
   // The array of quotes
-  results: {_id: string, content: string, author: string, tags: [string], length: number}[]
+  results: {_id: string, content: string, author: string, tags: [string], length:}[]
 }
 ```
 

--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -75,8 +75,7 @@ describe('GET /quotes/:id', () => {
     expect(response.body).toEqual({
       _id: quote._id,
       author: quote.author,
-      content: quote.content,
-      length: quote.length
+      content: quote.content
     })
   })
 

--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -88,7 +88,8 @@ describe('GET /quotes', () => {
       _id: expect.any(String),
       author: expect.any(String),
       content: expect.any(String),
-      tags: expect.any(Array)
+      tags: expect.any(Array),
+      length: expect.any(Number)
     })
     expect(body.results[0].tags).toContain('love')
     expect(body.results[0].tags).toContain('life')

--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -32,12 +32,12 @@ describe('GET /random', () => {
   it('Responds with a JSON object containing a single quote.', async () => {
     const response = await request(app).get('/random')
     expect(response.type).toBe('application/json')
-    expect(response.body).toEqual({
-      _id: expect.any(String),
-      author: expect.any(String),
-      content: expect.any(String),
-      length: expect.any(Number),
-    })
+      expect(response.body).toEqual({
+        _id: expect.any(String),
+        author: expect.any(String),
+        content: expect.any(String),
+        length: expect.any(Number),
+      })
   })
 
   it('Responds with a different quote on each request', async () => {
@@ -76,6 +76,7 @@ describe('GET /quotes/:id', () => {
       _id: quote._id,
       author: quote.author,
       content: quote.content,
+      length: quote.length
     })
   })
 

--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -69,7 +69,8 @@ describe('GET /quotes', () => {
       _id: expect.any(String),
       author: expect.any(String),
       content: expect.any(String),
-      tags: expect.any(Array)
+      tags: expect.any(Array),
+      length: expect.any(Number),
     })
   })
 

--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -36,6 +36,7 @@ describe('GET /random', () => {
       _id: expect.any(String),
       author: expect.any(String),
       content: expect.any(String),
+      length: expect.any(Number),
     })
   })
 

--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -40,6 +40,7 @@ describe('GET /random', () => {
         length: expect.any(Number),
         tags: expect.any(Array)
       })
+    expect(response.body.tags.find(tag => tag === 'love' || tag === 'life')).not.toBeUndefined()
   })
 
   it('Responds with a different quote on each request', async () => {
@@ -94,7 +95,6 @@ describe('GET /quotes', () => {
     expect(body.results[0].tags).toContain('love')
     expect(body.results[0].tags).toContain('life')
   })
-
 })
 
 describe('GET /authors', () => {

--- a/src/controllers/quotes/listQuotes.js
+++ b/src/controllers/quotes/listQuotes.js
@@ -50,7 +50,7 @@ module.exports = async function listQuotes(req, res, next) {
         .sort({ [sortBy]: sortOrder })
         .limit(limit)
         .skip(skip)
-        .select('content author'),
+        .select('content author length'),
       Quotes.countDocuments(filter),
     ])
 

--- a/src/controllers/quotes/listQuotes.js
+++ b/src/controllers/quotes/listQuotes.js
@@ -13,11 +13,20 @@ const Quotes = require('../../models/Quotes')
  */
 module.exports = async function listQuotes(req, res, next) {
   try {
-    const { author, authorId } = req.query
+    const { author, authorId, minlength = 0, maxlength = 99999999 } = req.query
     let { limit, skip = 0 } = req.query
 
     // Query filters
-    const filter = {}
+    const filter = {
+      // set a filter on attribute "length"
+      length: {
+        // $gte (greater than or equal to) matches anything of value at or above specified
+        $gte: Number(minlength),
+
+        // $lte (less than or equal to) matches anything at or below specified value
+        $lte: Number(maxlength),
+      },
+    }
 
     if (author) {
       // Search for quotes by author name (supports "fuzzy" search)
@@ -41,7 +50,7 @@ module.exports = async function listQuotes(req, res, next) {
         .sort({ [sortBy]: sortOrder })
         .limit(limit)
         .skip(skip)
-        .select('content author'),
+        .select('content author length'),
       Quotes.countDocuments(filter),
     ])
 

--- a/src/controllers/quotes/listQuotes.js
+++ b/src/controllers/quotes/listQuotes.js
@@ -50,7 +50,7 @@ module.exports = async function listQuotes(req, res, next) {
         .sort({ [sortBy]: sortOrder })
         .limit(limit)
         .skip(skip)
-        .select('content author length'),
+        .select('content author'),
       Quotes.countDocuments(filter),
     ])
 

--- a/src/controllers/quotes/listQuotes.js
+++ b/src/controllers/quotes/listQuotes.js
@@ -15,8 +15,13 @@ const getTagsFilter = require('../utils/getTagsFilter')
  */
 module.exports = async function listQuotes(req, res, next) {
   try {
-
-    const { author, authorId, tags, minlength = 0, maxlength = 99999999 } = req.query
+    const {
+      author,
+      authorId,
+      tags,
+      minLength = 0,
+      maxLength = 99999999,
+    } = req.query
     let { limit, skip = 0 } = req.query
 
     // Query filters
@@ -24,10 +29,10 @@ module.exports = async function listQuotes(req, res, next) {
       // set a filter on attribute "length"
       length: {
         // $gte (greater than or equal to) matches anything of value at or above specified
-        $gte: Number(minlength),
+        $gte: Number(minLength),
 
         // $lte (less than or equal to) matches anything at or below specified value
-        $lte: Number(maxlength),
+        $lte: Number(maxLength),
       },
     }
 

--- a/src/controllers/quotes/randomQuote.js
+++ b/src/controllers/quotes/randomQuote.js
@@ -6,8 +6,20 @@ const Quotes = require('../../models/Quotes')
  */
 module.exports = async function getRandomQuote(req, res, next) {
   try {
-    // Query filters
-    const filter = {}
+    // save our query parameters
+    const { minlength = 0, maxlength = 99999999 } = req.query
+
+    // Query Filters
+    const filter = {
+      // set a filter on attribute "length"
+      length: {
+        // $gte (greater than or equal to) matches anything of value at or above specified
+        $gte: Number(minlength),
+
+        // $lte (less than or equal to) matches anything at or below specified value
+        $lte: Number(maxlength),
+      },
+    }
 
     const [result] = await Quotes.aggregate([
       // Apply filters (if any)

--- a/src/controllers/quotes/randomQuote.js
+++ b/src/controllers/quotes/randomQuote.js
@@ -27,7 +27,7 @@ module.exports = async function getRandomQuote(req, res, next) {
       // Select a random document from the results
       { $sample: { size: 1 } },
       // Only include the following the fields
-      { $project: { _id: 1, content: 1, author: 1 } },
+      { $project: { _id: 1, content: 1, author: 1, length: 1 } },
     ])
 
     if (!result) {

--- a/src/controllers/quotes/randomQuote.js
+++ b/src/controllers/quotes/randomQuote.js
@@ -15,7 +15,7 @@ module.exports = async function getRandomQuote(req, res, next) {
       // Select a random document from the results
       { $sample: { size: 1 } },
       // Only include the following the fields
-      { $project: { _id: 1, content: 1, author: 1 } },
+      { $project: { _id: 1, content: 1, author: 1, length: 1 } },
     ])
 
     if (!result) {

--- a/src/controllers/quotes/randomQuote.js
+++ b/src/controllers/quotes/randomQuote.js
@@ -7,19 +7,18 @@ const getTagsFilter = require('../utils/getTagsFilter')
  */
 module.exports = async function getRandomQuote(req, res, next) {
   try {
-
     // save our query parameters
-    const { minlength = 0, maxlength = 99999999, tags} = req.query
+    const { minLength = 0, maxLength = 99999999, tags } = req.query
 
     // Query Filters
     const filter = {
       // set a filter on attribute "length"
       length: {
         // $gte (greater than or equal to) matches anything of value at or above specified
-        $gte: Number(minlength),
+        $gte: Number(minLength),
 
         // $lte (less than or equal to) matches anything at or below specified value
-        $lte: Number(maxlength),
+        $lte: Number(maxLength),
       },
     }
 

--- a/src/controllers/quotes/randomQuote.js
+++ b/src/controllers/quotes/randomQuote.js
@@ -27,7 +27,7 @@ module.exports = async function getRandomQuote(req, res, next) {
       // Select a random document from the results
       { $sample: { size: 1 } },
       // Only include the following the fields
-      { $project: { _id: 1, content: 1, author: 1, length: 1 } },
+      { $project: { _id: 1, content: 1, author: 1 } },
     ])
 
     if (!result) {


### PR DESCRIPTION
After looking into the code and learning some of the MongoDB stuff, it turned out to be a lot simpler than i thought in my issue. 
The only thing needed was a filter on `length` with the standard `$lte` and `$gte`properties set to their appropriate value in both `randomQuote.js` and `listQuotes.js`

After also remembering that unit testing exists, i added the length attribute properly to the response object as well as the unit test.

---

Added `minlength` and `maxlength` query parameters to the following endpoints

- `/quotes`
- `/random`

Reference #19