### PR TITLE
Enhancement: sort tags by number of quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ I originally built this for a freeCodeCamp project, and decided to publish for o
 ## Table of contents:
 
 - [Get a random quote](#get-random-quote)
-- [Search quotes](#search-quotes-beta)
+- [Search quotes](#search-quotes)
 - [Get Quote by ID](#get-quote-by-id)
-- [Search authors](#search-authors-beta)
-- [Get Author By ID](#get-author-by-id-beta)
+- [Search authors](#search-authors)
+- [Get Author By ID](#get-author-by-id)
 - [Usage](#usage)
 - [Live Example](#live-examples)
 
@@ -24,7 +24,7 @@ Returns a single random quote from the database
 
 | param    | type     | Description                                                  |
 | :------- | :------- | :----------------------------------------------------------- |
-| tags     | `String` | The list of tags. Tags can be separated by comma (`tags=life,technology` would match quotes with the tags "life" `AND` "technology") or pipe `|` (`tags=love|friendship` would match quotes with tags "love" `OR` "friendship").|
+| tags     | `String` | Filter random quote by tag(s). Takes a list of one or more tag names, separated by a comma (meaning `AND`) or a pipe (meaning `OR`). A comma separated list will match quotes that have **_all_** of the given tags. While a pipe (`|`) separated list will match quotes that have **_either_** of the provided tags. |
 
 
 #### Request
@@ -44,9 +44,9 @@ https://api.quotable.io/random
 }
 ```
 
-### Search Quotes (beta)
+### List Quotes
 
-Get quotes from the database using various filter and sorting options. All parameters are optional.
+Get a paginated list of all quotations in the database. This method supports several filter and sorting options. 
 
 #### Query parameters
 
@@ -56,7 +56,7 @@ Get quotes from the database using various filter and sorting options. All param
 | authorId | `String` | Filter quotes by author ID.                                  |
 | limit    | `Int`    | The number of quotes to return per request. (for pagination).|
 | skip     | `Int`    | The number of items to skip (for pagination).                |
-| tags     | `String` | The list of tags. Tags can be separated by comma (`tags=life,technology` would match quotes with the tags "life" `AND` "technology") or pipe `|` (`tags=love|friendship` would match quotes with tags "love" `OR` "friendship").|
+| tags     | `String` | Filter quotes by tag(s). Takes a list of one or more tag names, separated by a comma (meaning `AND`) or a pipe (meaning `OR`). A comma separated list will match quotes that have **_all_** of the given tags. While a pipe (`|`) separated list will match quotes that have **_either_** of the provided tags. |
 
 #### Request
 
@@ -102,9 +102,9 @@ https://api.quotable.io/quotes/:id
 }
 ```
 
-### Search Authors (beta)
+### List Authors
 
-Search the database for authors using various filter/sorting options. All parameters are optional. By default, it returns all authors in alphabetical order.
+Get a paginated list of all authors in the database. This method supports several filter and sorting options. 
 
 #### Query parameters
 
@@ -139,7 +139,7 @@ https://api.quotable.io/authors
 }
 ```
 
-### Get Author By ID (beta)
+### Get Author By ID
 
 Get all quotes a specific author
 

--- a/src/controllers/authors/listAuthors.js
+++ b/src/controllers/authors/listAuthors.js
@@ -1,6 +1,7 @@
 const clamp = require('lodash/clamp')
 const escapeRegExp = require('lodash/escapeRegExp')
 const Authors = require('../../models/Authors')
+const parseSortOrder = require('../utils/parseSortOrder')
 
 /**
  * List Authors
@@ -19,21 +20,18 @@ module.exports = async function listAuthors(req, res, next) {
     let { sortBy, sortOrder, limit, skip } = req.query
     const filter = {}
 
+    // Supported parameter values
+    const Values = { sortBy: ['name', 'quoteCount'] }
+    // The default sort order depends on the `sortBy` field
+    const defaultSortOrder = { name: 1, quoteCount: -1 }
+
     if (name) {
       // TODO: remove this param in favor of a separate search endpoint
       filter.name = new RegExp(escapeRegExp(name), 'gi')
     }
 
-    // Supported parameter values
-    const Values = {
-      sortBy: ['name', 'quoteCount'],
-      sortOrder: ['asc', 'desc', 'ascending', 'descending', '1', '-1'],
-    }
-    // The default order depends on the sortBy field.
-    const defaultOrder = sortBy === 'quoteCount' ? -1 : 1
-
     sortBy = Values.sortBy.includes(sortBy) ? sortBy : 'name'
-    sortOrder = Values.sortOrder.includes(sortOrder) ? sortOrder : defaultOrder
+    sortOrder = parseSortOrder(sortOrder) || defaultSortOrder[sortBy] || 1
     limit = clamp(parseInt(limit), 1, 50) || 20
     skip = parseInt(skip) || 0
 

--- a/src/controllers/tags/listTags.js
+++ b/src/controllers/tags/listTags.js
@@ -1,16 +1,31 @@
 const Tags = require('../../models/Tags')
+const parseSortOrder = require('../utils/parseSortOrder')
 
-/**
- * Get list of tags from the database.
- */
 module.exports = async function listTags(req, res, next) {
   try {
-    const results = await Tags.find({}).select('name')
+    let { sortBy, sortOrder } = req.query
 
-    res.status(200).json({
-      count: results.length,
-      results,
-    })
+    // Supported parameter values
+    const Values = { sortBy: ['name', 'quoteCount'] }
+    // The default sort order depends on the `sortBy` field
+    const defaultSortOrder = { name: 1, quoteCount: -1 }
+
+    sortBy = Values.sortBy.includes(sortBy) ? sortBy : 'name'
+    sortOrder = parseSortOrder(sortOrder) || defaultSortOrder[sortBy] || 1
+
+    const results = await Tags.aggregate([
+      {
+        $lookup: {
+          from: 'quotes',
+          localField: 'name',
+          foreignField: 'tags',
+          as: 'quoteCount',
+        },
+      },
+      { $addFields: { quoteCount: { $size: '$quoteCount' } } },
+      { $sort: { [sortBy]: sortOrder } },
+    ])
+    res.json(results)
   } catch (error) {
     return next(error)
   }

--- a/src/controllers/utils/parseSortOrder.js
+++ b/src/controllers/utils/parseSortOrder.js
@@ -1,0 +1,17 @@
+/**
+ * Parses a user supplied input for the `sortOrder` param. Returns the
+ * corresponding numeric value or `null` (if `input` is invalid).
+ *
+ * Supported values:
+ * - "asc" | "ascending" | "1"
+ * - "desc" | "descending" | "-1"
+ */
+module.exports = function parseSortOrder(input) {
+  let value = input
+  // If value is one of the supported keywords ("asc", "ascending",
+  // "desc", "descending"), convert it to the corresponding numeric value.
+  if (/^asc(ending)?$|^desc(ending)?$/.test(String(value))) {
+    value = /^asc/.test(input) ? 1 : -1
+  }
+  return Math.abs(value) === 1 ? Number(value) : null
+}

--- a/src/models/Quotes.js
+++ b/src/models/Quotes.js
@@ -11,6 +11,6 @@ const QuoteSchema = new Schema({
 })
 
 // To support full text search
-QuoteSchema.index({ content: 'text', author: 'text' })
+QuoteSchema.index({ content: 'text', author: 'text' }, { name: 'textIndex' })
 
 module.exports = model('Quote', QuoteSchema)

--- a/src/models/Tags.js
+++ b/src/models/Tags.js
@@ -6,7 +6,6 @@ const TagSchema = new Schema({
   name: { type: String, required: true },
 })
 
-// To support full text search
-TagSchema.index({ name: 'text' })
+TagSchema.index({ name: 1 }, { name: 'nameIndex' })
 
 module.exports = model('Tag', TagSchema)


### PR DESCRIPTION
- Add `sortBy`  params to `/tags` endpoint. Tags can be sorted by
`name` (default) or by `quoteCount`.

- Update README

Part of issue #8