### PR TITLE
docs: add query parameters to list tags endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,13 @@ Get a list of all tags
 GET /tags
 ```
 
+#### Query parameters
+
+| param     | type                           | Description                                                   |
+| :-------- | :----------------------------- | :------------------------------------------------------------ |
+| sortBy    | `enum: ['name', 'quoteCount']` | `Default: "name"` <br> The field used to sort tags.         |
+| sortOrder | `enum: ['asc', 'desc']`        | `Default: depends on sortBy` <br> The order in which results are sorted.         |
+
 #### Response
 
 ```ts


### PR DESCRIPTION
Solves #25,
Updated the query parameters for [README#list-tags](https://github.com/lukePeavey/quotable#list-tags), which although in the issue #25 has been mentioned as [README#getTags](https://github.com/lukePeavey/quotable#getTags), which doesn't exist. So I continued with the one that was prevailing in the real documentation.