### PR TITLE
feature: get author by slug

### DIFF
--- a/src/controllers/authors/getAuthorBySlug.js
+++ b/src/controllers/authors/getAuthorBySlug.js
@@ -1,0 +1,37 @@
+const createError = require('http-errors')
+const Authors = require('../../models/Authors')
+const Quotes = require('../../models/Quotes')
+
+/**
+ * Get a single author by slug
+ */
+module.exports = async function getAuthorById(req, res, next) {
+  try {
+    const { slug } = req.params
+
+    if (!slug) {
+      return next(createError(422, 'Slug is required'))
+    }
+    // Get the author
+    const author = await Authors.findOne({ slug: `${slug}` }).select(
+      '-__v -aka'
+    )
+
+    if (!author) {
+      return next(createError(404, 'The requested resource could not be found'))
+    }
+    // Get quotes by this author
+    const quotes = await Quotes.find({ authorId: author._id }).select(
+      '-__v -authorId'
+    )
+
+    res.status(200).json({
+      _id: author._id,
+      name: author.name,
+      quoteCount: author.quoteCount,
+      quotes,
+    })
+  } catch (error) {
+    return next(error)
+  }
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,6 +5,7 @@ const searchQuotes = require('./controllers/search/searchQuotes')
 const randomQuote = require('./controllers/quotes/randomQuote')
 const listAuthors = require('./controllers/authors/listAuthors')
 const getAuthorById = require('./controllers/authors/getAuthorById')
+const getAuthorById = require('./controllers/authors/getAuthorBySlug')
 const listTags = require('./controllers/tags/listTags')
 
 const router = Router()

--- a/src/routes.js
+++ b/src/routes.js
@@ -21,6 +21,7 @@ router.get('/random', randomQuote)
  **-----------------------------------------------*/
 router.get('/authors', listAuthors)
 router.get('/authors/:id', getAuthorById)
+router.get('/authors/slug/:slug', getAuthorBySlug)
 
 /**------------------------------------------------
  ** Tags

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,7 +5,8 @@ const searchQuotes = require('./controllers/search/searchQuotes')
 const randomQuote = require('./controllers/quotes/randomQuote')
 const listAuthors = require('./controllers/authors/listAuthors')
 const getAuthorById = require('./controllers/authors/getAuthorById')
-const getAuthorById = require('./controllers/authors/getAuthorBySlug')
+const getAuthorBySlug = require('./controllers/authors/getAuthorBySlug')
+
 const listTags = require('./controllers/tags/listTags')
 
 const router = Router()


### PR DESCRIPTION
Adds a new endpoint to get a single author by `slug`.  This is equivalent to the  existing `/author/:id` endpoint except it uses the `slug` field to identify the author. 

### Path

```HTTP
GET /author/slug/:slug
```

### Response

The response is a single `Author` object. It includes the author details and the full list of quotes by the author. 

```ts
{
  // A unique id for this author
  _id: string
  // The author slug 
  slug: string
  // The authors full name
  name: string
  // The number of quotes by this author
  quoteCount: string
  // An array containing all quotes by this author (not paginated)
  quotes: Array<{
    _id: string
    // The quotation text
    content: string
    // The full name of the author
    author: string
    // An array of tag names for this quote
    tags: string[]
    // The length of quote (number of characters)
    length: number
  }>
}
```

