### PR TITLE
Enhancement: author slugs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,3 @@
 {
-  "cSpell.words": [
-    "circleci",
-    "moesif"
-  ]
+  "cSpell.words": ["S", "Søren", "circleci", "deburr", "moesif", "ren", "soren"]
 }

--- a/__tests__/routes/listQuotes.test.js
+++ b/__tests__/routes/listQuotes.test.js
@@ -22,6 +22,7 @@ describe('GET /quotes', () => {
     const quote = body.results[0]
     expect(quote._id).toEqual(expect.any(String))
     expect(quote.author).toEqual(expect.any(String))
+    expect(quote.authorSlug).toEqual(expect.any(String))
     expect(quote.content).toEqual(expect.any(String))
     expect(quote.tags).toEqual(expect.any(Array))
     expect(quote.length).toEqual(expect.any(Number))

--- a/__tests__/routes/randomQuote.test.js
+++ b/__tests__/routes/randomQuote.test.js
@@ -18,6 +18,7 @@ describe('GET /random', () => {
     // Response should be a single `Quote` object with the following fields
     expect(body._id).toEqual(expect.any(String))
     expect(body.author).toEqual(expect.any(String))
+    expect(body.authorSlug).toEqual(expect.any(String))
     expect(body.content).toEqual(expect.any(String))
     expect(body.tags).toEqual(expect.any(Array))
     expect(body.length).toEqual(expect.any(Number))

--- a/src/controllers/utils/slug.js
+++ b/src/controllers/utils/slug.js
@@ -1,0 +1,28 @@
+const deburr = require('lodash/deburr')
+const words = require('lodash/words')
+const toLower = require('lodash/toLower')
+
+/**
+ * Converts the given `string` to a slug.
+ * Same as lodash#kebabCase
+ *
+ * @param {string} [string=''] The string to convert.
+ * @returns {string} Returns the slug
+ * @example
+ *
+ * slug('Foo Bar')
+ * // => 'foo-bar'
+ *
+ * slug('foo mcBar')
+ * // => 'foo-mc-bar'
+ *
+ * slug('John O'Reilly')
+ * // => 'john-o-reilly'
+ *
+ * slug('Søren Kierkegaard')
+ * // => 'soren-kierkegaard'
+ */
+module.exports = function slug(input) {
+  const string = deburr(input).replace(/['\u2019]/g, '')
+  return words(string).map(toLower).join('-')
+}

--- a/src/models/Authors.js
+++ b/src/models/Authors.js
@@ -3,7 +3,7 @@ const shortid = require('shortid')
 
 const AuthorSchema = new Schema({
   _id: { type: String, default: shortid.generate },
-  // Slug can be used instead of `_id` to identify an author.
+  // A unique ID derived from the author's name.
   slug: { type: String, required: true },
   // The authors full name
   name: { type: String, required: true },

--- a/src/models/Quotes.js
+++ b/src/models/Quotes.js
@@ -2,11 +2,19 @@ const { Schema, model } = require('mongoose')
 const shortid = require('shortid')
 
 const QuoteSchema = new Schema({
+  // @internal
   _id: { type: String, default: shortid.generate },
+  // The quotation text
   content: { type: String, required: true },
+  // The full display name of the quote's author
   author: { type: String, required: true },
+  // The author `slug` is a unique ID derived from the author's name.
+  authorSlug: { type: String, required: true },
+  // @deprecated in favor of authorSlug
   authorId: { type: String, required: true },
+  // An array of tags for this quote
   tags: { type: [String], required: true },
+  // The length of the quote (total number of characters)
   length: { type: Number, required: true },
 })
 


### PR DESCRIPTION
## Summary

- Adds an `authorSlug` fields to quotes
- The `author` param (on the `/random` and `/quotes` endpoint) now accepts author slug **or** name


Adding the `authorSlug` field to quotes provides a way to get details about the author of a quote returned by the `/random` or `/quotes` endpoints.  For example, if you want to get the bio and profile image (#38) for the author of a quote, you would make an additional request to get the author details using the value of `authorSlug` as the `slug`. 


**Get author details (slug) (#53)**

```HTTP
GET /authors/slug/:slug
```

**Get all quotes by author (slug)**

```http
GET /quotes?author={slug}
```

**Get a random quote by author (slug)**

```HTTP
GET /random?author={slug}
```
