### PR TITLE
feature: search (beta)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,6 @@ jobs:
 
     working_directory: ~/quotable
 
-    environment:
-      MONGODB_URI: mongodb://localhost:27017/test
-
     steps:
       - checkout
 
@@ -33,10 +30,6 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-
-      - run:
-          name: Seeding database
-          command: npm run -s database:seed data/sample
 
       - run:
           name: Running ESLint

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-  "cSpell.words": ["S", "Søren", "circleci", "deburr", "moesif", "ren", "soren"]
+  "cSpell.words": [
+    "S",
+    "Søren",
+    "circleci",
+    "deburr",
+    "moesif",
+    "ren",
+    "soren",
+    "stopwords"
+  ]
 }

--- a/__tests__/routes/searchQuotes.test.js
+++ b/__tests__/routes/searchQuotes.test.js
@@ -1,5 +1,6 @@
 require('dotenv').config()
 const request = require('supertest')
+const { stringify } = require('query-string')
 const app = require('../../src/app')
 const db = require('../../scripts/db')
 
@@ -9,8 +10,9 @@ afterAll(async () => db.close())
 
 describe('GET /search/quotes', () => {
   it(`Response is OK`, async () => {
-    const query = 'a divided house'
-    const URL = `/search/quotes?query=${encodeURI(query)}`
+    const query = { query: 'freedom' }
+    const URL = `/search/quotes?query=${stringify(query)}`
+
     const { status, type, body } = await request(app).get(URL)
 
     // Response matches schema

--- a/src/controllers/search/searchAuthors.js
+++ b/src/controllers/search/searchAuthors.js
@@ -1,0 +1,170 @@
+const clamp = require('lodash/clamp')
+const createError = require('http-errors')
+const Authors = require('../../models/Authors')
+const toBoolean = require('../utils/toBoolean')
+const parseName = require('../utils/parseName')
+
+/**
+ * Search Operators
+ */
+const SearchOperator = {
+  // The autocomplete operator
+  // This operator can only be used with a search index that is configured for
+  // autocomplete search.
+  // @see https://docs.atlas.mongodb.com/reference/atlas-search/autocomplete
+  autocomplete: 'autocomplete',
+  // The `text` operator performs a standard text search and is similar to
+  // mongodb's legacy text search feature.
+  // @see https://docs.atlas.mongodb.com/reference/atlas-search/text
+  text: 'text',
+}
+
+/**
+ * Search index Names
+ * @see https://docs.atlas.mongodb.com/reference/atlas-search/index-definitions/
+ */
+const SearchIndex = {
+  // The default search index
+  default: 'default',
+  // This search index is configured for autocomplete search and must be used
+  // with the `autocomplete` operator.
+  autocomplete: 'autocompleteIndex',
+}
+
+/**
+ * Search for authors by name
+ *
+ * This feature is intended to power a search bar that can display autocomplete
+ * suggestions as the user types. It is powered by Atlas Search, mongodb's new
+ * search engine feature.
+ *
+ *
+ * @warn This feature is a work in progress. The API may change at any time.
+ * @warn Atlas Search is not supported on local mongodb deployments
+ *
+ * @param {Object} req
+ * @param {Object} req.query
+ * @param {string} req.query.query the search query
+ * @param {Object} [req.query.autocomplete = true] Enable autocomplete mode.
+ * @param {number} [req.query.fuzzy = 0] The number of characters that can
+ *     be modified in order to create a match. This allows for minor
+ *     misspellings and typos. This param is not currently implemented.
+ * @param {number} [req.query.matchThreshold = 2] The minimum number of search
+ *     terms that must match for an author to be included in results. If this
+ *     is set to 1, results will include all authors that match at least one
+ *     term in the query. So query="John F Kennedy" would  return all authors
+ *     that match "john" or "kennedy". When this is set to `2`, if the query
+ *     contains two or more terms, at least two of those terms must match for
+ *     an author to be included in the results. In this case, query="john F
+ *     Kennedy", would only return authors that match "John" and "Kennedy". And
+ *     query="John Quincy Adams" would return authors that match any two of the
+ *     three terms "john", "quincy" and "adams".
+ * @param {Object} [req.query.limit = 20] results per page
+ * @param {Object} [req.query.skip = 20] offset for pagination
+ *
+ * @see https://docs.atlas.mongodb.com/reference/atlas-search/
+ * @see https://docs.atlas.mongodb.com/reference/atlas-search/text
+ * @see https://docs.atlas.mongodb.com/reference/atlas-search/compound/
+ * @see https://docs.atlas.mongodb.com/reference/atlas-search/autocomplete
+ * @see https://docs.atlas.mongodb.com/reference/atlas-search/index-definitions/
+ * @see https://docs.atlas.mongodb.com/reference/atlas-search/scoring
+ */
+module.exports = async function searchAuthors(req, res, next) {
+  try {
+    const {
+      query,
+      autocomplete = true,
+      matchThreshold = 2,
+      skip,
+      limit,
+    } = req.query
+
+    // Parse the query into terms.
+    // =======================================================================
+    // "Terms" include all words except for: initials, prefixes, suffixes, and
+    // stopwords.
+    // -----------------------------------------------------
+    //
+    //   term      term
+    //     |         |
+    //   John  F.  Kennedy  Jr.
+    //         |             |
+    //      initial        suffix
+    // -----------------------------------------------------
+    //             term       term
+    //              |          |
+    //    Saint Augustine of Hippo
+    //     |              |
+    //   prefix         stopword
+    //
+    // -----------------------------------------------------
+    const { terms, value } = parseName(query)
+
+    if (!query) {
+      // Respond with error if query param is empty
+      return next(createError(422, 'Missing required parameter: `query`'))
+    }
+
+    // Pagination params
+    const $limit = clamp(limit, 0, 50) || 20
+    const $skip = clamp(skip, 0, 1e3) || 0
+    const $project = { __v: 0, aka: 0 }
+
+    // Let `indexName` be the name of the search index to use. This name
+    // corresponds to a search index configured via the Atlas dashboard.
+    const indexName = toBoolean(autocomplete)
+      ? SearchIndex.autocomplete
+      : SearchIndex.default
+
+    // Let `operator` be the name of the search operator to use
+    const operator = toBoolean(autocomplete)
+      ? SearchOperator.autocomplete
+      : SearchOperator.text
+
+    // Let `$search` be the search query
+    // NOTE: The `compound` operator
+    const $search = {
+      index: indexName,
+      compound: {},
+    }
+
+    // Required clause
+    // ...
+    $search.compound.must = {
+      compound: {
+        minimumShouldMatch: Math.min(terms.length, matchThreshold),
+        should: terms.map(term => ({
+          [operator]: { query: term, path: 'name' },
+        })),
+      },
+    }
+
+    // This clause checks author `names` against the entire search string to
+    // improve sorting accuracy. This
+    // 1) allows things like initials, prefixes and suffixes, which are
+    //    not considered "terms", to be taken into account when sorting
+    //    results.
+    // 2) ensures that results are in the correct order when multiple authors
+    //    match all of the "terms" in the query. For example:
+    //    query="John Adams" =>
+    //    | 1. "John Adams" (should be first because it matches exactly)
+    //    | 2. "John Quincy Adams"
+    $search.compound.should = [{ [operator]: { query: value, path: 'name' } }]
+
+    const [results, [meta]] = await Promise.all([
+      // Get paginated search results
+      Authors.aggregate([{ $search }, { $skip }, { $limit }, { $project }]),
+      // Get the total number of results that match the search
+      Authors.aggregate([{ $search }, { $count: 'totalCount' }]),
+    ])
+
+    // Pagination info
+    const { totalCount = 0 } = meta || {}
+    const count = results.length
+    const lastItemIndex = skip + count < totalCount ? skip + count : null
+    // Send response
+    res.json({ count, totalCount, lastItemIndex, results })
+  } catch (error) {
+    return next(error)
+  }
+}

--- a/src/controllers/search/searchQuotes.js
+++ b/src/controllers/search/searchQuotes.js
@@ -38,7 +38,7 @@ module.exports = async function searchQuotes(req, res, next) {
 
     if (fields.some(field => !supportedFields.includes(field))) {
       // Respond with error if `fields` param is invalid
-      return next(createError(422, 'Invalid request: `path`'))
+      return next(createError(422, 'Invalid parameter: `fields`'))
     }
 
     // The search query

--- a/src/controllers/utils/parseName.js
+++ b/src/controllers/utils/parseName.js
@@ -1,0 +1,84 @@
+const toWords = require('lodash/words')
+const toLower = require('lodash/toLower')
+
+// List of prefixes
+const prefix = [
+  'mr',
+  'mrs',
+  'ms',
+  'miss',
+  'saint',
+  'general',
+  'brother',
+  'captain',
+  'count',
+  'countess',
+  'dr',
+  'duke',
+  'father',
+  'reverend',
+  'rev',
+  'sir',
+  'sister',
+]
+
+// The list of suffixes
+const suffix = [
+  'Jr',
+  'Sr',
+  'I',
+  'II',
+  'III',
+  'IV',
+  'V',
+  'MD',
+  'DDS',
+  'PhD',
+  'DVM',
+]
+
+// A list of stop words commonly used in names
+const stopwords = ['the', 'of', 'de']
+
+// Array of regExps for prefixes, suffixes, stopwords
+const regExps = [prefix, suffix, stopwords].map(list => {
+  return new RegExp(`^(${list.join('|')})$`, 'i')
+})
+
+/**
+ * Returns `true` if the given `word` is a search term. For this case,
+ * search terms are all words except initials, prefixes, suffixes, and
+ * stop words.
+ *
+ * @param {string} word
+ * @returns {boolean}
+ * @example
+ * // Initials
+ * isSecondaryTerm("L")     // => false
+ * // Prefixes
+ * isSecondaryTerm("Saint") // => false
+ * // Suffixes
+ * isSecondaryTerm("Jr")    // => false
+ * // stop words
+ * isSecondaryTerm("the")    // => false
+ */
+const isSearchTerm = word => {
+  if (word.length <= 1) return false
+  return !regExps.some(regExp => regExp.test(word))
+}
+
+/**
+ * Breaks a name down into terms. Search terms are all words except initials,
+ * prefixes, suffixes, and stop words.
+ */
+function parseName(str) {
+  // The string (strip punctuation, convert to lowercase)
+  const value = toLower(str)
+  // Split the string into words
+  const words = toWords(value).slice(0, 10)
+  // Get search terms
+  const terms = words.filter(isSearchTerm)
+  return { terms, value }
+}
+
+module.exports = parseName

--- a/src/controllers/utils/toBoolean.js
+++ b/src/controllers/utils/toBoolean.js
@@ -1,0 +1,33 @@
+/**
+ * Converts string, number, or boolean value to a boolean.
+ *
+ * @example
+ * toBoolean(true)
+ * // => true
+ * toBoolean("true")
+ * // => true
+ * toBoolean(1)
+ * // => true
+ * toBoolean("1")
+ *
+ * toBoolean(false)
+ * // => false
+ * toBoolean("false")
+ * // => false
+ * toBoolean("0")
+ * // => false
+ * toBoolean(0)
+ * // => false
+ * toBoolean(null)
+ * // => false
+ * toBoolean(undefined)
+ * // => false
+ *
+ */
+module.exports = function toBoolean(value) {
+  const number = parseInt(value)
+  const string = String(value)
+  return !Number.isNaN(number)
+    ? Boolean(number)
+    : string.toLowerCase() === 'true'
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -2,6 +2,7 @@ const { Router } = require('express')
 const listQuotes = require('./controllers/quotes/listQuotes')
 const getQuoteById = require('./controllers/quotes/getQuoteById')
 const searchQuotes = require('./controllers/search/searchQuotes')
+const searchAuthors = require('./controllers/search/searchAuthors')
 const randomQuote = require('./controllers/quotes/randomQuote')
 const listAuthors = require('./controllers/authors/listAuthors')
 const getAuthorById = require('./controllers/authors/getAuthorById')
@@ -34,5 +35,6 @@ router.get('/tags', listTags)
  ** Search
  **-----------------------------------------------*/
 router.get('/search/quotes', searchQuotes)
+router.get('/search/authors', searchAuthors)
 
 module.exports = router


### PR DESCRIPTION
## Summary

Adds new search endpoints powered by [Atlas Search](https://docs.atlas.mongodb.com/atlas-search).  Atlas Search is a new MongoDB feature that provides advanced search capabilities using the [Lucene](https://lucene.apache.org/core) engine. 

This feature is still a work in progress.

## Search Authors
 
```HTTP
GET /search/authors
```


Adds a new endpoint to search  for authors by name.  This is intended to power a search bar with autocomplete suggestions. 
- Supports real autocomplete
- Search results are sorted by score. 
- Customizable threshold for match (see comments in controllers/searchAuthors.js)

## Search Quotes

 
```HTTP
GET /search/quotes
```

Updates the existing `/search/quotes` endpoint. It is now powered by Atlas Search.

- Adds a `fields` param. This allows you to specify which field(s) to search by. Supported fields are `content`, `author`, and `tags`. The value can be a comma separated list of fields. By default it will search all simultaneously
- Supports keyword or exact phrase search. Wrap query in quotes to search for exact phrase.
- Results are sorted by text matching score


**Search for quotes by author name**

Will return all quotes where author name includes the term "kennedy" 

```HTTP
GET /search/quotes?query=kennedy&fields=author
```

**Search for quotes by content**

Will return all quotes whose content includes the terms "love" or "friendship"
```HTTP
GET /search/quotes?query=love+friendship&fields=content
```
