### PR TITLE
feature: get multiple random quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ https://api.quotable.io
 ## API Reference <!-- omit in toc -->
 
 - [Get random quote](#get-random-quote)
+- [Get Random Quotes (beta)](#get-random-quotes-beta)
 - [List Quotes](#list-quotes)
 - [Get Quote By ID](#get-quote-by-id)
 - [List Authors](#list-authors)
@@ -103,6 +104,90 @@ GET /random?minLength=100&maxLength=140
 
 <br>
 
+## Get Random Quotes (beta)
+
+```HTTP
+GET /quotes/random
+```
+
+Get a random quote (or quotes) from the database.  This method supports several filters that can be used to get random quotes with specific properties (ie tags, quote length, etc.)
+
+By default, this methods returns a single random quote. You can specify the number of random quotes to return via the `limit` parameter.  
+
+> ⚠️ This method is equivalent to the `/random` endpoint. The only difference is the response format:
+> 
+> Instead of retuning a single `Quote` object, this method returns an array of `Quote` objects.  This makes it possible to specify the number of random quotes to retrieve. 
+
+
+<br>
+
+| param     | type     | Description                                                                                                                                                                                                                                                                                                                          | 
+| :-------- | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | 
+| limit     | `Int`    | `default: 1` &nbsp; `min: 1` &nbsp; `max: 100` <br> The number of random quotes to retrieve.                                                                                                                                                                       |
+| maxLength | `Int`    | The maximum Length in characters ( can be combined with `minLength` )                                                                                                                                                                                                                                                                |
+| minLength | `Int`    | The minimum Length in characters ( can be combined with `maxLength` )                                                                                                                                                                                                                                                                |
+| tags      | `String` | Get a random quote with specific tag(s). This takes a list of one or more tag names, separated by a comma (meaning `AND`) or a pipe (meaning `OR`). A comma separated list will match quotes that have **_all_** of the given tags. While a pipe (`\|`) separated list will match quotes that have **any one** of the provided tags. |
+| author    | `String` | Get a random quote by one or more authors. The value can be an author `name` or `slug`. To include quotes by multiple authors, provide a pipe-separated list of author names/slugs.                                                                                                                                                  |
+| authorId  | `String` | `deprecated` <br><br> Same as `author` param, except it uses author `_id` instead of `slug`                                                                                                                                                                                                                                          | 
+
+**Response**
+
+```ts
+// An array containing one or more Quotes
+Array<{
+  _id: string
+  // The quotation text
+  content: string
+  // The full name of the author
+  author: string
+  // The `slug` of the quote author
+  authorSlug: string
+  // The length of quote (number of characters)
+  length: number
+  // An array of tag names for this quote
+  tags: string[]
+}>
+```
+
+
+**Examples**
+
+Get random quote [try in browser](https://api.quotable.io/quotes/random)
+
+```HTTP
+GET /quotes/random
+```
+
+Get 5 random quotes [try in browser](https://api.quotable.io/quotes/random?limit=3)
+
+```HTTP
+GET /quotes/random?limit=3
+```
+
+
+Random Quote with tags "technology" **`AND`** "famous-quotes" [try in browser](https://api.quotable.io/quotes/random?tags=technology,famous-quotes)
+
+```HTTP
+GET /quotes/random?tags=technology,famous-quotes
+```
+
+Random Quote with tags "History" **`OR`** "Civil Rights" [try in browser](https://api.quotable.io/quotes/random?tags=history|civil-rights)
+
+```HTTP
+GET /quotes/random?tags=history|civil-rights
+```
+
+Random Quote with a maximum length of 50 characters [try in browser](https://api.quotable.io/quotes/random?maxLength=50)
+
+```HTTP
+GET /quotes/random?maxLength=50
+```
+
+Random Quote with a length between 100 and 140 characters [try in browser](https://api.quotable.io/quotes/random?minLength=100&maxLength=140)
+
+```HTTP
+GET /quotes/random?minLength=100&maxLength=140
+```
 ## List Quotes
 
 ```HTTP

--- a/README.md
+++ b/README.md
@@ -110,20 +110,20 @@ GET /random?minLength=100&maxLength=140
 GET /quotes/random
 ```
 
-Get a random quote (or quotes) from the database.  This method supports several filters that can be used to get random quotes with specific properties (ie tags, quote length, etc.)
+Get one or more random quotes from the database.  This method supports several filters that can be used to get random quotes with specific properties (ie tags, quote length, etc.)
 
 By default, this methods returns a single random quote. You can specify the number of random quotes to return via the `limit` parameter.  
 
-> ⚠️ This method is equivalent to the `/random` endpoint. The only difference is the response format:
+> ⚠️ This method is similar to the `/random` endpoint. The only difference is the response format:
 > 
-> Instead of retuning a single `Quote` object, this method returns an array of `Quote` objects.  This makes it possible to specify the number of random quotes to retrieve. 
+> Instead of retuning a single `Quote` object, this method returns an `Array` of `Quote` objects.
 
 
 <br>
 
 | param     | type     | Description                                                                                                                                                                                                                                                                                                                          | 
 | :-------- | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | 
-| limit     | `Int`    | `default: 1` &nbsp; `min: 1` &nbsp; `max: 100` <br> The number of random quotes to retrieve.                                                                                                                                                                       |
+| limit     | `Int`    | `default: 1` &nbsp; `min: 1` &nbsp; `max: 50` <br> The number of random quotes to retrieve.                                                                                                                                                                       |
 | maxLength | `Int`    | The maximum Length in characters ( can be combined with `minLength` )                                                                                                                                                                                                                                                                |
 | minLength | `Int`    | The minimum Length in characters ( can be combined with `maxLength` )                                                                                                                                                                                                                                                                |
 | tags      | `String` | Get a random quote with specific tag(s). This takes a list of one or more tag names, separated by a comma (meaning `AND`) or a pipe (meaning `OR`). A comma separated list will match quotes that have **_all_** of the given tags. While a pipe (`\|`) separated list will match quotes that have **any one** of the provided tags. |

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,2 +1,3 @@
 export const MAX_LIMIT = 150
 export const DEFAULT_LIMIT = 20
+export const MAX_RANDOM_COUNT = 2000

--- a/src/controllers/quotes/randomQuote.v2.js
+++ b/src/controllers/quotes/randomQuote.v2.js
@@ -1,0 +1,77 @@
+import createError from 'http-errors'
+import { clamp } from 'lodash-es'
+import Quotes from '../../models/Quotes.js'
+import Authors from '../../models/Authors.js'
+import getTagsFilter from '../utils/getTagsFilter.js'
+import getLengthFilter from '../utils/getLengthFilter.js'
+import slug from '../utils/slug.js'
+import { MAX_RANDOM_COUNT } from '../../constants.js'
+
+/**
+ * Get a single random quote
+ */
+export default async function getRandomQuote(req, res, next) {
+  try {
+    const {
+      minLength,
+      maxLength,
+      tags,
+      author,
+      authorId,
+      authorSlug,
+      limit = 1,
+    } = req.query
+
+    // Max number of random quotes to retrieve in a single request
+    const size = clamp(parseInt(limit), 1, MAX_RANDOM_COUNT)
+
+    const filter = {}
+
+    if (minLength || maxLength) {
+      filter.length = getLengthFilter(minLength, maxLength)
+    }
+
+    if (tags) {
+      filter.tags = getTagsFilter(tags)
+    }
+
+    if (authorId) {
+      // @deprecated
+      // Use the `author` param to filter by author `name` or `slug` instead
+      filter.authorId = { $in: authorId.split('|') }
+    }
+
+    if (author) {
+      if (/,/.test(author)) {
+        // If `author` is a comma-separated list, respond with an error
+        const message = 'Multiple authors should be separated by a pipe.'
+        return next(createError(400, message))
+      }
+      // Filter quotes by author slug.
+      filter.authorSlug = { $in: author.split('|').map(slug) }
+    }
+
+    if (authorSlug) {
+      // @deprecated
+      // use `author` param instead
+      filter.authorSlug = { $in: author.split('|').map(slug) }
+    }
+
+    const results = await Quotes.aggregate([
+      // Apply filters (if any)
+      { $match: filter },
+      // Select a random document from the results
+      { $sample: { size } },
+      { $project: { __v: 0, authorId: 0 } },
+    ])
+    const count = results.length
+    if (count === 0) {
+      // This should only occur when using filter params
+      const message = 'Could not find any matching quotes'
+      return next(createError(404, message))
+    }
+    res.status(200).json(results)
+  } catch (error) {
+    return next(error)
+  }
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,6 +4,7 @@ import getQuoteById from './controllers/quotes/getQuoteById.js'
 import searchQuotes from './controllers/search/searchQuotes.js'
 import searchAuthors from './controllers/search/searchAuthors.js'
 import randomQuote from './controllers/quotes/randomQuote.js'
+import randomQuotes from './controllers/quotes/randomQuote.v2.js'
 import listAuthors from './controllers/authors/listAuthors.js'
 import getAuthorById from './controllers/authors/getAuthorById.js'
 import getAuthorBySlug from './controllers/authors/getAuthorBySlug.js'
@@ -16,6 +17,7 @@ router.get('/internal/uip', (request, response) => response.send(request.ip))
  ** Quotes
  **-----------------------------------------------*/
 router.get('/quotes', listQuotes)
+router.get('/quotes/random', randomQuotes)
 router.get('/quotes/:id', getQuoteById)
 router.get('/random', randomQuote)
 


### PR DESCRIPTION
# Background

There was a feature request  to be able to fetch multiple random quotes in a single request (#173).  This has been requested a few times in the past. I think it would be a useful feature. 

I added a new  random quote endpoint that can fetch _one or more_ random quotes.  By default, it gets a single random quote, just like the current `/random` endpoint.  However, you can specify the number of random quotes to retrieve via the `limit` parameter.   

This endpoint could potentially replace the existing `/random` endpoint. The `/random` endpoint would continue to function as it does now, but it would be removed from the public docs in favor of this method. 

# Pull Request 

Adds a new endpoint that gets **one or more** random quotes, matching the given query parameters. 

```HTTP
GET /quotes/random
```

It supports all of the same parameters as the existing `/random` endpoint.   The primary difference is the response format. Instead of a single `Quote` object, **this endpoint returns an `Array` containing one or more `Quote` objects**


## Response

```ts
// An array containing one or more Quotes
Array<{
  _id: string
  // The quotation text
  content: string
  // The full name of the author
  author: string
  // The `slug` of the quote author
  authorSlug: string
  // The length of quote (number of characters)
  length: number
  // An array of tag names for this quote
  tags: string[]
}>
```

## Usage Examples


Fetch a single random quote 
```js
const response = await fetch(`${API}/quotes/random`)
// The response is an array containing a single quote
const [{ content, author }] = await response.json()
console.log(`${content}  --${author}`)
```

Fetch 3 random quotes 
```js
const response = await fetch(`${API}/quotes/random?limit=3`)
// Response is an array containing 3 random quotes
const quotes = await response.json()
quotes.forEach(({ content, author }) => console.log(`${content} --${author}`))
```
